### PR TITLE
Disable extra mouse wheel handling for mono at runtime.

### DIFF
--- a/MapView/Forms/MainView/MainViewF.cs
+++ b/MapView/Forms/MainView/MainViewF.cs
@@ -623,7 +623,14 @@ namespace MapView
 			ssMain.Renderer = new CustomToolStripRenderer();
 
 #if !__MonoCS__
-			Application.AddMessageFilter(this);
+			if (Type.GetType ("Mono.Runtime") == null) // WindowFromPoint is windows specific. If that ever works with Mono remove that check. Better: Check if function exists or replace function.
+			{
+				Application.AddMessageFilter(this);
+			}
+			else
+			{
+				Console.WriteLine ("Mousewheel (partly) not handled. Reason: Mono runtime detected.");
+			}
 #endif
 			Cursor.Current = Cursors.Default;
 			//Logfile.Log("About to show MainView ..." + Environment.NewLine);

--- a/McdView/McdviewF.cs
+++ b/McdView/McdviewF.cs
@@ -553,7 +553,16 @@ namespace McdView
 
 #if !__MonoCS__
 			if (!isInvoked)
-				Application.AddMessageFilter(this);
+			{
+				if (Type.GetType ("Mono.Runtime") == null) // WindowFromPoint is windows specific. If that ever works with Mono remove that check. Better: Check if function exists or replace function.
+				{
+					Application.AddMessageFilter(this);
+				}
+				else
+				{
+					Console.WriteLine ("Mousewheel (partly) not handled. Reason: Mono runtime detected.");
+				}
+			}
 #endif
 		}
 

--- a/PckView/PckViewF.cs
+++ b/PckView/PckViewF.cs
@@ -417,7 +417,16 @@ namespace PckView
 
 #if !__MonoCS__
 			if (!isInvoked)
-				Application.AddMessageFilter(this);
+			{
+				if (Type.GetType ("Mono.Runtime") == null) // WindowFromPoint is windows specific. If that ever works with Mono remove that check. Better: Check if function exists or replace function.
+				{
+					Application.AddMessageFilter(this);
+				}
+				else
+				{
+					Console.WriteLine ("Mousewheel (partly) not handled. Reason: Mono runtime detected.");
+				}
+			}
 #endif
 		}
 


### PR DESCRIPTION
This needs reconsidering if ever WindowFromPoint, and maybe sendMessage, gets to works with Mono.
It would be safer to runtime-check if that function exists or implement the mouse wheeling differently.